### PR TITLE
Document Synergy Discount for buffToken attunement and add NatSpec to _revertInsufficientFunds

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Owners can spend an active token's kinetic energy (Active Charge) to apply tempo
 You can mix and match effects for a designated time period (up to 7 days). The cost dynamically scales based on the duration, the number of links, and the magnitude of the requested powers:
 - **Efficiency**: Temporarily boosts the base efficiency of all outgoing links.
 - **Attunement**: Temporarily shifts your token's frequency to mimic a different Planar Archetype, altering how it synergizes with neighbors.
+  - **Synergy Discount**: Attunement magnitude gets a **25% discount** when the chosen plane has a strong affinity with the token's primary planar link.
 - **Amplification**: Multiplies any incoming energy landing on the token.
 - **Anchor**: Binds energy to the vessel. When discharged, the token retains 25% of its power rather than dissipating completely.
 - **Reverb**: Creates a feedback loop. A portion of the energy successfully pushed to outgoing links echoes back to the source.

--- a/contracts/DigilToken.sol
+++ b/contracts/DigilToken.sol
@@ -672,6 +672,8 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
 
     // Add Value and Distributions
 
+    /// @dev    Reverts with {InsufficientFunds} using the caller-provided required amount.
+    /// @param  required The exact native-value amount expected for the operation (in wei).
     function _revertInsufficientFunds(uint256 required) private pure {
         revert InsufficientFunds(required);
     }
@@ -2756,6 +2758,8 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
     ///         - A precomputed `magnitude` score is calculated from requested parameters:
     ///             * `efficiencyBonus + amplification`
     ///             * + tiered attunement weight (scaled by attunement plane and short-duration boost)
+    ///               and reduced by 25% when the chosen attunement has strong affinity with the token's
+    ///               primary planar link (Synergy Discount)
     ///             * + costs for requested flags and tier tags
     ///             * + a small flat weight if `appearance` tags are provided
     ///         - Cost uses {_buffCost(magnitude, duration, linkCount)} where:


### PR DESCRIPTION
### Motivation
- Ensure on-chain NatSpec and repository docs describe the new Synergy Discount behavior applied to attunement in `buffToken` (25% magnitude reduction when the chosen attunement plane has strong affinity with the token's primary planar link).
- Provide clear documentation for the private helper used to revert insufficient native-value operations so its intent and parameter semantics are explicit in code.

### Description
- Updated `DigilToken.buffToken` NatSpec to explicitly state the Synergy Discount: attunement magnitude is reduced by 25% when the selected attunement has strong affinity with the token's primary planar link. (`contracts/DigilToken.sol`).
- Added NatSpec comments to the private helper `function _revertInsufficientFunds(uint256 required) private pure` describing its purpose and the `required` parameter. (`contracts/DigilToken.sol`).
- Updated `README.md` Buffs section to document the Synergy Discount so external docs match the on-chain behavior. (`README.md`).
- Modified files: `contracts/DigilToken.sol`, `README.md`.

### Testing
- Attempted to run `forge test` in the workspace, but the command is unavailable in this environment and the test run failed with `forge: command not found`.
- No other automated tests were executed in this environment; changes were inspected and committed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a21a808d6083269e665d051c5ca7ad)