### PR TITLE
Clarify vaulted NFT recall lifecycle and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,8 @@ Digils can act as "spirit vessels" for other NFTs.
 
 - **Deposit**: When you send an external ERC-721 to the Digil contract, you are charged a Coin fee, and a new Digil is minted wrapped around your NFT.
 - **Recall**: `recallToken(address account, uint256 digilId)`  
-  Once the Digil completes at least one activation cycle, the owner can recall the underlying NFT **as long as the Digil remains active**. If the Digil is discharged into an inactive state, recallability is cleared and the Digil must be activated again to make the wrapped NFT recallable. Pulling the artifact out of the vessel causes the Digil to suffer a power bleed, leaving behind an empty, but highly charged and historically rich, shell.
-- **Safeguard**: Wrapped tokens can only be recalled when protocol state says the vessel has completed the required lifecycle gates (and the Digil is currently active).
+  Once the Digil completes at least one activation cycle, an approved operator can recall the underlying NFT. Recallability is sticky until explicitly cleared: it is removed when the wrapped NFT is recalled, or when a full discharge settles while the Digil is inactive. Deactivation alone does not clear the flag. Pulling the artifact out of the vessel causes the Digil to suffer a power bleed, leaving behind an empty, but highly charged and historically rich, shell.
+- **Safeguard**: Wrapped tokens can only be recalled when protocol state says the vessel has completed the required lifecycle gates and currently marks the attachment as recallable.
  
 
 ---

--- a/contracts/DigilToken.sol
+++ b/contracts/DigilToken.sol
@@ -990,11 +990,13 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
     ///      * `recallable` for this Digil remains `false` initially; the external token
     ///        cannot be recalled yet.
     ///  - The external token becomes *recallable* after the Digil completes an
-    ///    **activation** distribution cycle, and remains recallable while the Digil is active:
+    ///    **activation** distribution cycle.
     ///      * When `_distribute(tokenId, false)` finishes (called from {activateToken}),
     ///        it sets `_contractTokens[contractTokenAddress][tokenId].recallable = true`
     ///        if and only if `_contractTokenExists[contractTokenAddress][externalTokenId]`
     ///        is still `true` (i.e., the token remains vaulted).
+    ///      * Recallability persists until explicitly cleared by {recallToken}
+    ///        or by a full discharge cycle that settles while inactive.
     ///  - A subsequent call to {recallToken}:
     ///      * Transfers the external ERC721 back to the current Digil owner.
     ///      * Sets `recallable` back to `false`.
@@ -1046,10 +1048,12 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
     ///    `recallable`:
     ///        _contractTokens[account][tokenId].recallable == true.
     ///    This flag is set when a full **activation** distribution cycle
-    ///    completes via {_distribute} called from {activateToken}, and is maintained while
-    ///    the Digil remains active, provided the external token is still vaulted (i.e.
+    ///    completes via {_distribute} called from {activateToken}, provided the
+    ///    external token is still vaulted (i.e.
     ///        _contractTokenExists[account][externalTokenId] == true
     ///    at the end of the distribution).
+    ///    After being set, this flag remains true until it is explicitly cleared
+    ///    by a successful recall or by a full discharge completion while inactive.
     ///
     ///  Effects:
     ///  - Reads the external tokenId from `_contractTokens[account][tokenId].tokenId`.
@@ -1267,7 +1271,10 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
     ///     Interpretation:
     ///       - The external ERC721 is still held by this contract and was marked
     ///         recallable when a full activation distribution cycle completed via
-    ///         {_distribute} called from {activateToken}, and remains recallable while the Digil is active.
+    ///         {_distribute} called from {activateToken}.
+    ///       - This state can persist across later deactivation and is only
+    ///         cleared by {recallToken} or by a full discharge cycle that
+    ///         settles while inactive.
     ///       - It can now be reclaimed by an approved operator using {recallToken}.
     ///
     ///  4. Recalled (historical-only)
@@ -1290,7 +1297,7 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
     ///    and is:
     ///      * set to `true` when a full activation distribution cycle completes and the
     ///        external token is still vaulted, and
-    ///      * maintained while the Digil remains active (and the external token remains vaulted), and
+    ///      * retained until explicitly cleared (while the external token remains vaulted), and
     ///      * set back to `false` either when:
     ///          - {recallToken} succeeds, or
     ///          - a full discharge cycle completes ({dischargeToken}) for an inactive token (unwind),


### PR DESCRIPTION
### Motivation
- The NatSpec comments and README contained misleading language implying that wrapped NFTs could only be recalled while a Digil was currently active.  
- The contract code actually sets `recallable` after an activation settlement and keeps it until explicitly cleared by a recall or an inactive full discharge, which should be documented.  
- The README also did not reflect that an approved operator (per ERC721 approvals) can perform the recall, and that simple deactivation does not clear recallability.  

### Description
- Updated `contracts/DigilToken.sol` NatSpec around `onERC721Received`, `recallToken`, and `tokenAttachment` to state that `recallable` is set after the activation distribution completes and is retained until cleared by `recallToken` or a full discharge that settles while inactive.  
- Clarified that `recallToken` follows ERC721 approval semantics (approved operator may invoke it) and that state updates clear `recallable` before the external `safeTransferFrom`.  
- Updated `README.md` Vaulting section to reflect the sticky `recallable` behavior, approved-operator authorization, and that deactivation alone does not clear recallability.  

### Testing
- Ran repository searches to validate and locate relevant references using `rg -n "recall|vault|attachment|external ERC721|onERC721Received"` and `rg -n "remains active|currently active|owner can recall"` and confirmed occurrences were updated, and these searches completed successfully.  
- Inspected diffs with `git diff -- contracts/DigilToken.sol README.md` to verify the exact changes, and the diff output matched the intended documentation updates.  
- Committed the documentation updates (`git commit`) on the working branch; no unit tests were modified or executed as this change is documentation/NatSpec only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a9f3da9483268a01101e3cad2d3d)