### PR TITLE
Update DigilGovernor NatSpec and README to reflect outcome-staking model

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The on-chain governance contract for DigilCoin that executes approved proposals.
 
 - **Voting**: Uses quadratic counting (weight is the square root of held power) and is **NFT-gated** (voters must own or be approved for a Digil token to cast a ballot).
 - **Raw Vote Power Composition**: Delegated liquid votes plus time-locked coin power and a lock-duration bonus.
-- **Staking, Signaling & Locking**: Users can lock coins for a time-based voting bonus, stake coins on pending/active proposals (refundable only if proposals are not defeated/expired), or burn coins as a non-refundable **signal** of support/conviction while a proposal is pending/active.
+- **Locking & Outcome Staking**: Users can lock coins for a time-based voting bonus. They can also stake on proposal outcomes while proposals are pending/active, then claim a market-settled payout after finalization (winner takes proportional share of the losing side, canceled proposals refund both sides, and orphaned losing pools can be burned).
 - **Execution Safety**: Proposals execute through timelock controls, preserving review windows for privileged actions.
 
 ### Digil Timelock

--- a/contracts/DigilGovernor.sol
+++ b/contracts/DigilGovernor.sol
@@ -15,7 +15,7 @@ import {IERC20Burnable} from "contracts/IERC20Burnable.sol";
 
 /// @title Digil Governor
 /// @author gSOLO
-/// @notice Governance contract for DigilCoin with: (1) NFT-gated voting, (2) vote weight boosted by time-locked coins, (3) quadratic counting, (4) timelock execution, and (5) optional stakeing mechanic.
+/// @notice Governance contract for DigilCoin with: (1) NFT-gated voting, (2) vote weight boosted by time-locked coins, (3) quadratic counting, (4) timelock execution, and (5) an optional proposal outcome staking market.
 /// @dev Extends OpenZeppelin Governor with custom `_getVotes` (raw power) + `_countVote` (quadratic tally). Time is sourced from the token’s ERC6372 clock (`token().clock()` / `token().CLOCK_MODE()`).
 /// @custom:security-contact security@digil.co.in
 // OPTIMIZATION: Removed 'GovernorSettings' inheritance
@@ -124,15 +124,14 @@ contract DigilGovernor is Governor, GovernorStorage, GovernorVotes, GovernorTime
     error NoLockedCoins();
     /// @notice Thrown when staking actions are attempted in an invalid Governor state.
     error InvalidProposalState(ProposalState state);
-    /// @notice Thrown when a stake-related action is attempted but user/total stake is zero or already burned.
+    /// @notice Thrown when a user attempts to claim from a proposal where they have no stake.
     error NoStake();
     /// @notice Thrown when attempting to claim or sweep on a market that is still pending or active.
     error MarketNotFinalized();
     /// @notice Thrown when a user attempts to claim winnings but their chosen side lost, or they already claimed.
     error StakeLostOrNothingToClaim();
-    /// @notice Thrown when a sweep operation is attempted but there are no orphaned stakes to burn.
+    /// @notice Thrown when a burn operation is attempted but there are no orphaned stakes to burn.
     error NoOrphanedStakes();
-    /// @notice Thrown when vote params are missing (tokenId is required for NFT-gated voting).
 
     /// @param _token The IVotes token used for delegation-based voting power (DigilCoin).
     /// @param _timelock Timelock controller used for queued/executed operations.
@@ -485,7 +484,7 @@ contract DigilGovernor is Governor, GovernorStorage, GovernorVotes, GovernorTime
     }
 
     /// @notice Evaluates the current state of a proposal and translates it into a prediction market outcome.
-    /// @dev    Internal helper used by `claimWinnings` and `sweepOrphanedStakes` to consolidate logic and save bytecode.
+    /// @dev    Internal helper used by `claim` and `burn` to consolidate logic and save bytecode.
     /// @param  proposalId The ID of the proposal being evaluated.
     /// @return outcome An integer representing the market result: 1 = FOR won, 0 = AGAINST won, 2 = DRAW (Canceled).
     /// @custom:reverts MarketNotFinalized if the proposal is still voting (Pending or Active).


### PR DESCRIPTION
### Motivation
- Remove outdated "signaling" language and align documentation/comments to the revised staking mechanic which uses an outcome-settled staking market rather than burn-as-signal behavior.
- Ensure contract NatSpec accurately describes current runtime behavior and helper references so on-chain docs and off-chain tooling remain consistent.

### Description
- Replace README governance line `Staking, Signaling & Locking` with `Locking & Outcome Staking` and add a brief description of the market-settled payout semantics in `README.md`.
- Update `contracts/DigilGovernor.sol` NatSpec to clarify the staking feature as an outcome staking market in the top-level `@notice` and remove an accidental duplicate comment line.
- Clarify error comments by rewording `NoStake` and `NoOrphanedStakes` descriptions and update the helper-function comment to reference the current `claim` and `burn` functions.
- Commit changes to the repository (files modified: `README.md`, `contracts/DigilGovernor.sol`).

### Testing
- Ran `git diff -- README.md contracts/DigilGovernor.sol` to inspect the produced diff and confirm the exact edits; the command completed successfully.
- Searched for stale identifiers with `rg -n "signal|signaling|stakeing|claimWinnings|sweepOrphanedStakes" README.md contracts/DigilGovernor.sol` to verify removal of old terms and received no matches after edits.
- Performed a `git commit` which completed successfully and recorded the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4c813d74083269cb01eb1e0504728)