### PR TITLE
Document testing-only contracts and deployment helper address mapping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,8 @@ For any logic change, agents should validate using the strongest available check
 
 When validating `DigilToken` behavior in the Desktop Remix IDE, use this strict bootstrap sequence:
 
+- `DigilTestLibrary.sol`, `IDigilToken.sol`, and `NFT.sol` are testing-only contracts/files and should be treated as test support.
+
 1. Deploy `DigilCoin` first with the default admin account (generally Remix account 0: `0x5B38Da6a701c568545dCfcB03FcB875f56beddC4`).
 2. Deploy `DigilToken` with:
    - the same default admin as initial owner,
@@ -125,6 +127,9 @@ When validating `DigilToken` behavior in the Desktop Remix IDE, use this strict 
 3. On the deployed `DigilCoin`, call `grantRole` with:
    - `role`: `0x9f2df0fed2c77648de5860a4cc508cd0818c85b8b8a1ab4ceeef8d981c8956a6` (`MINTER_ROLE`),
    - `account`: the deployed `DigilToken` contract address.
+4. After both deployments are complete, set helper address references as follows:
+   - put the deployed `DigilCoin` address into `getCoins`
+   - put the deployed `DigilToken` address into `getToken`
 
 This role assignment is required before `DigilToken` flows that mint DIGIL can succeed.
 
@@ -210,4 +215,3 @@ Before finalizing:
 - [ ] Ran relevant validation commands (or documented environment blockers).
 - [ ] Updated README when behavior/setup/flows changed.
 - [ ] Summarized risks, assumptions, and follow-ups in final output.
-


### PR DESCRIPTION
### Motivation
- Clarify which files are test-only and document the expected post-deployment helper address wiring for Remix-based `DigilToken` tests to reduce confusion during manual test setup.

### Description
- Update `AGENTS.md` to mark `DigilTestLibrary.sol`, `IDigilToken.sol`, and `NFT.sol` as testing-only and add a follow-up step instructing to place the deployed `DigilCoin` address into `getCoins` and the deployed `DigilToken` address into `getToken`, and commit the change.

### Testing
- Verified the documentation change and commit by running `git diff -- AGENTS.md` and `git show --stat --oneline HEAD`, both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a912bd4cf88326a3db127fc591a8e0)