### PR TITLE
Add `setSpendWeight` step to DigilToken test bootstrap in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,11 +127,14 @@ When validating `DigilToken` behavior in the Desktop Remix IDE, use this strict 
 3. On the deployed `DigilCoin`, call `grantRole` with:
    - `role`: `0x9f2df0fed2c77648de5860a4cc508cd0818c85b8b8a1ab4ceeef8d981c8956a6` (`MINTER_ROLE`),
    - `account`: the deployed `DigilToken` contract address.
-4. After both deployments are complete, set helper address references as follows:
+4. On the deployed `DigilCoin`, call `setSpendWeight` with:
+   - `account`: the deployed `DigilToken` contract address,
+   - `weight`: `10000` (100%).
+5. After both deployments are complete, set helper address references as follows:
    - put the deployed `DigilCoin` address into `getCoins`
    - put the deployed `DigilToken` address into `getToken`
 
-This role assignment is required before `DigilToken` flows that mint DIGIL can succeed.
+These role and spend-weight assignments are required before `DigilToken` flows that mint DIGIL can succeed.
 
 If environment lacks required tooling, state limitation clearly and provide a follow-up command list for maintainers.
 


### PR DESCRIPTION
### Motivation
- Ensure the Desktop Remix IDE bootstrap instructions include the required `setSpendWeight` configuration so `DigilToken` flows that mint DIGIL do not fail due to missing spend-weight setup.

### Description
- Added a new step instructing to call `setSpendWeight` on the deployed `DigilCoin` with `account` set to the deployed `DigilToken` address and `weight` set to `10000` (100%).
- Renumbered the subsequent helper-address setup and clarified that both `grantRole` and `setSpendWeight` assignments are required before minting flows succeed.

### Testing
- Verified the documentation change with `git diff -- AGENTS.md` and confirmed the updated section with `nl -ba AGENTS.md | sed -n '118,145p'`, both succeeded. 
- No Solidity compilation or automated contract tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a96a1a2884832688efa0d86e8772cd)