### PR TITLE
Harden chargeTokenAs blacklist enforcement and align docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,13 @@ For any logic change, agents should validate using the strongest available check
 - Verify no obvious formatting regressions.
 - Provide exact commands run and outcomes.
 
+### Security review checklist (for behavior changes)
+
+- Check role/admin boundaries for new and modified state-changing functions.
+- Check reentrancy surfaces around ETH/ERC20/ERC721 interactions and verify CEI ordering.
+- Check batching/replay flags and epoch/ring-buffer rollover behavior for edge-case regressions.
+- Check that NatSpec/README claims match implemented revert behavior and access policy.
+
 ### Test targeting guidance
 
 - `DigilCoin.sol` changes → run `tests/DigilCoin_test.sol` first.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ To empower the sigil, participants offer material value (ETH) and energetic valu
 - **Inactive Tokens**: Charging builds "Potential Energy." Participants supply coins and the required minimum ETH.
 - **Active Tokens**: If the token has no links, coins become "Kinetic Energy" (Active Charge). If the token is linked, the energy is distributed across the network based on the strength and affinity of those links. Unused ETH goes to the token's owner.
 - **Proxy Contribution Support**: `chargeTokenAs` allows sponsored or delegated contribution flows while preserving the canonical contributor ledger.
-- **Participation Definition**: In `chargeTokenAs`, participation means who receives contribution attribution (`contributor`), not who pays gas/calls. A blacklisted caller may still trigger `chargeTokenAs` for another, non-blacklisted contributor.
+- **Participation Definition**: In `chargeTokenAs`, participation means who receives contribution attribution (`contributor`), not who pays gas/calls. Both caller and contributor must be opted in (not blacklisted) for the charge to proceed.
 
 ### 3. Activating
 `activateToken(uint256 tokenId)`

--- a/contracts/DigilGovernor.sol
+++ b/contracts/DigilGovernor.sol
@@ -90,7 +90,7 @@ contract DigilGovernor is Governor, GovernorStorage, GovernorVotes, GovernorTime
     /// @param amount The amount of tokens staked.
     event Stake(uint256 indexed proposalId, address indexed user, bool supportFor, uint256 amount);
     /// @notice Emitted when a user claims their winnings or refund.
-    /// @dev    `amount` is the post-bounty burn amount, after any 1% caller bounty is paid.
+    /// @dev    `amount` is the total payout transferred to the claimer for this market.
     /// @param proposalId The ID of the proposal.
     /// @param user The address of the user claiming.
     /// @param amount The total amount of tokens sent back to the user (principal + winnings).

--- a/contracts/DigilToken.sol
+++ b/contracts/DigilToken.sol
@@ -1908,7 +1908,7 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
 
             if (value < minimumValue) _revertInsufficientFunds(minimumValue);
             
-            // Transfer coins from the contributor to this contract.
+            // Transfer coins from the caller (sponsor) to this contract.
             _coinsFromSender(coins);
 
         }
@@ -1969,10 +1969,9 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
 
     /// @notice Charges a token on behalf of another contributor.
     ///         Requires a value sent greater than or equal to the token's incremental value for each coin.
-    /// @dev    Requires that the contributor is not blacklisted and the token exists.
-    ///         Participation attribution is based on `contributor`. The caller may be
-    ///         blacklisted and can still trigger this function for a non-blacklisted
-    ///         contributor, but the caller is not attributed as the participant.
+    /// @dev    Requires that both the caller and `contributor` are not blacklisted,
+    ///         and the token exists. Participation attribution is based on
+    ///         `contributor`.
     ///         If token.incrementalValue == 0, charging does not require ETH; any ETH sent is treated as surplus value
     ///         (credited as token value or distributed per the active/inactive path). If token.incrementalValue > 0,
     ///         ETH must satisfy the per-charge minimum derived from incrementalValue.
@@ -1981,6 +1980,7 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
     /// @param  coins The coin units used in the charge.
     /// @return True if the token was successfully charged.
     function chargeTokenAs(address contributor, uint256 tokenId, uint256 coins) public payable returns(bool) {
+        _notOnBlacklist(_msgSender());
         _notOnBlacklist(contributor);
         _checkTokenExists(tokenId);
         


### PR DESCRIPTION
### Motivation

- Close a policy gap where an opted-out caller could previously sponsor `chargeTokenAs` calls for non-blacklisted contributors, which conflicted with opt-out semantics and README claims.
- Ensure code comments and NatSpec accurately reflect runtime behavior for charge flow and event semantics.
- Improve future reviews by adding a concise security-review checklist to the agent guidance file.

### Description

- Enforce caller opt-in in `DigilToken.chargeTokenAs` by calling `_notOnBlacklist(_msgSender())` so both sponsor and attributed contributor must be opted in before charging proceeds.
- Clarify the non-linked charging comment to reflect that coin transfers are pulled from the caller (sponsor) at runtime.
- Update README to state that both caller and contributor must be opted in for `chargeTokenAs` flows.
- Correct `DigilGovernor` `Claim` event NatSpec to describe the actual payout semantics and extend `AGENTS.md` with a security review checklist for behavior changes.
- No storage layout changes were made and the change is narrowly scoped to entrance checks and documentation.

### Testing

- Reviewed changes with `git diff -- contracts/DigilToken.sol contracts/DigilGovernor.sol README.md AGENTS.md` and committed the patch successfully.
- Attempted to run test tooling with `forge test -q` but `forge` is not available in the environment so automated tests could not be executed (`forge: command not found`).
- Attempted to verify compiler with `solc --version` but `solc` is not installed in the environment (`solc: command not found`).
- Performed static inspection and targeted greps/reads of modified files to validate consistency and NatSpec alignment (no runtime failures observed in code review).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad00ddabe08326a09970b6950c662e)