### PR TITLE
Allow link upgrades at MAX_LINKS by gating max-link check to new-link path

### DIFF
--- a/contracts/DigilToken.sol
+++ b/contracts/DigilToken.sol
@@ -2547,10 +2547,13 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
         //_checkTokenExists(tokenId);
         _checkTokenExists(linkId);        
         _authorizeAndTouch(tokenId, t);
-        require(t.links.length < MAX_LINKS, "DIGIL: Too Many Links");
 
         // Existing link state
         uint8 baseEfficiency = t.linkEfficiency[linkId].base;
+        bool isNewLink = (baseEfficiency == 0);
+        if (isNewLink) {
+            require(t.links.length < MAX_LINKS, "DIGIL: Too Many Links");
+        }
 
         // Validate link: tokens must be different, destination must be non-planar,
         // and the new efficiency must strictly improve on the current base.
@@ -2584,8 +2587,7 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
         // Update base efficiency in storage.
         t.linkEfficiency[linkId].base = efficiency;
 
-        // If this is a brand-new link (no previous baseEfficiency), add it to the list.
-        bool isNewLink = (baseEfficiency == 0);
+        // If this is a brand-new link, add it to the list.
         if (isNewLink) {
             t.links.push(linkId);
         }

--- a/tests/DigilTokenB_test.sol
+++ b/tests/DigilTokenB_test.sol
@@ -266,4 +266,44 @@ contract BetaTestSuite {
             Assert.ok(true, "Incorrect error for zero value");
         }
     }
+
+    // #sender: account-0
+    /// #value: 1200000000000000
+    function testLinkTokenAtMaxLinksUpgradeBehavior() external payable {
+        uint256 coinMultiplier = 10 ** 18;
+
+        bool approved = coins.approve(address(digil), 200000 * coinMultiplier);
+        Assert.ok(approved, "Coin approval failed");
+
+        uint256 tokenId = digil.createToken{value: 100000000000000}(0, 0, false, 0, "Max Link Source");
+        uint256[] memory destinations = new uint256[](11);
+        for (uint256 i; i < destinations.length; ++i) {
+            destinations[i] = digil.createToken{value: 100000000000000}(0, 0, false, 0, "Max Link Destination");
+        }
+
+        // Fill up to MAX_LINKS (10) with new links.
+        digil.linkToken(tokenId, destinations[0], 10);
+        for (uint256 i = 1; i < 10; ++i) {
+            digil.linkToken(tokenId, destinations[i], 10);
+        }
+
+        (, , , , uint256 links, , , , ) = digil.tokenData(tokenId);
+        Assert.equal(links, 10, "Token should be at MAX_LINKS");
+
+        // Upgrading an existing link at max links should succeed.
+        digil.linkToken(tokenId, destinations[0], 20);
+        (, , , , links, , , , ) = digil.tokenData(tokenId);
+        Assert.equal(links, 10, "Upgrading should not change link count");
+
+        (uint256 linkId, uint8 baseEfficiency, ) = digil.tokenLinkAt(tokenId, 0);
+        Assert.equal(linkId, destinations[0], "Unexpected upgraded link id");
+        Assert.equal(baseEfficiency, 20, "Existing link should upgrade at MAX_LINKS");
+
+        // Adding a new 11th link should still revert.
+        try digil.linkToken(tokenId, destinations[10], 10) {
+            Assert.ok(false, "Adding a new link at MAX_LINKS should fail");
+        } catch {
+            Assert.ok(true, "Expected Too Many Links revert for new link");
+        }
+    }
 }


### PR DESCRIPTION
### Motivation
- Fix a correctness bug in `linkToken` where upgrades to an existing link were blocked when `t.links.length == MAX_LINKS` because the max-links guard ran before reading existing link state.
- Preserve current economics and insertion behavior for genuine new links while allowing legitimate upgrades when at the cap.

### Description
- Read the existing `baseEfficiency` first and derive `isNewLink = (baseEfficiency == 0)` before enforcing the link-cap check by moving the `MAX_LINKS` guard inside the `isNewLink` branch; this allows upgrades when `baseEfficiency > 0` even if `t.links.length == MAX_LINKS`.
- Keep the original new-link behavior intact by only pushing `linkId` onto `t.links` when `isNewLink` is true and reusing the same coin-cost/upgrade logic.
- Add a regression test `testLinkTokenAtMaxLinksUpgradeBehavior` in `tests/DigilTokenB_test.sol` that fills a token to `MAX_LINKS`, verifies upgrading an existing link at cap succeeds, and verifies adding an 11th new link still reverts.

### Testing
- Ran lightweight repository checks: `git diff --check` succeeded.
- Attempted local compiler/tooling checks: `solc --version` failed because `solc` was not installed in the environment, and `npx hardhat compile` failed due to npm/registry access (403), so Solidity compilation and test execution could not be run here.
- The new test was added to the test suite but automated Solidity tests were not executed in this environment due to the toolchain/network limitations described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5b0e82908326af9009fa2b6a84f3)