### PR TITLE
Align IDigilToken with DigilToken ABI and emitted events

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ A non-custodial safety hatch. If you contributed to a token that has been comple
 `setOptStatus(bool optOut)`
 
 Accounts can willingly blacklist themselves via this function by paying a small fee. Blacklisted accounts cannot send/receive Digils, participate in charging, or withdraw pending Coins while opted out. They can, however, always withdraw their pending ETH. Opting out does not itself reset any already-accumulated pending Coin bonus timing state. This is useful for individuals who wish to permanently exit the gameplay loop.
+- **Event Surface**: Opt state transitions emit `OptStatus(address account, bool optOut)` for both opt-in and opt-out transitions.
 - **Transfer Lock While Opted Out**: Opted-out accounts cannot transfer their Digils until they opt back in by paying the opt-in fee.
 - **Approvals Are Not Retroactively Revoked**: Opt-out blocks direct actions by the opted-out account but does not invalidate previously granted ERC-721 operator approvals; approved operators can still act where contract checks allow.
 
@@ -266,6 +267,10 @@ Accounts can willingly blacklist themselves via this function by paying a small 
   - `tokenLinkAt(uint256 tokenId, uint256 index)`
   - `tokenAttachment(uint256 tokenId)`
   - `configuration()`
+- **Lifecycle/Event ABI Notes**:
+  - Batch lifecycle continuation emits `Batch(uint256 tokenId)` while activation/discharge are in progress.
+  - Buff application emits `Buff(uint256 tokenId)`; buff parameters are read through `tokenBuff(uint256 tokenId)`.
+  - Priming emits `Prime(uint256 tokenId)`.
 - **Batch Safety**: Sensitive lifecycle transitions are protected by batch-locks. If a token is mid-activation, it cannot be transferred, charged, or updated until the community finishes the batch processing.
 
 ---

--- a/contracts/IDigilToken.sol
+++ b/contracts/IDigilToken.sol
@@ -3,18 +3,17 @@ pragma solidity ^0.8.34;
 
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /// @title Interface for Digil Token (NFT)
 /// @notice Interface for the DigilToken contract used for the creation, charging, and activation of Digital Sigils on the Ethereum Blockchain
 interface IDigilToken is IERC721, IERC721Receiver {
     // Events
     event Configure(uint256 coinRate, uint256 incrementalValue, uint256 transferValue, uint16 batchSize);
-    event OptOut(address indexed account);
-    event OptIn(address indexed account);
+    event OptStatus(address indexed account, bool optOut);
     event Whitelist(address indexed account, uint256 indexed tokenId);
     event Restrict(uint256 indexed tokenId);
     event Update(uint256 indexed tokenId);
+    event Batch(uint256 indexed tokenId);
     event Activate(uint256 indexed tokenId);
     event Deactivate(uint256 indexed tokenId);
     event Charge(address indexed addr, uint256 indexed tokenId, uint256 coins, uint256 value);
@@ -22,9 +21,9 @@ interface IDigilToken is IERC721, IERC721Receiver {
     event Discharge(uint256 indexed tokenId);
     event Link(uint256 indexed tokenId, uint256 indexed linkId, uint8 efficiency, uint256 affinityBonus);
     event Unlink(uint256 indexed tokenId, uint256 indexed linkId);
-    event Buff(uint256 indexed tokenId, uint8 efficiencyBonus, uint8 attunement, uint8 amplification, uint16 flags, uint256 duration);
+    event Buff(uint256 indexed tokenId);
     event Stabilize(uint256 indexed tokenId);
-    event PendingDistribution(address indexed addr, uint256 coins, uint256 value);
+    event Prime(uint256 indexed tokenId);
     event Contribute(address indexed addr, uint256 indexed tokenId, uint256 value);
     event Enrich(uint256 indexed tokenId, uint256 value);
     event Reclaim(address indexed addr, uint256 indexed tokenId, uint256 value);
@@ -40,11 +39,8 @@ interface IDigilToken is IERC721, IERC721Receiver {
     function configure(uint256 coins, uint256 incrementalValue, uint256 transferValue, uint16 batchSize) external;
     function configuration() external view returns (uint256 coinRate, uint256 incrementalValue, uint256 transferValue, uint16 batchSize);
 
-    // Sweep (Admin Function)
-    function sweep(address token) external;
-
     // Withdraw
-    function withdraw() external payable returns (uint256 coins, uint256 value);
+    function withdraw() external returns (uint256 coins, uint256 value);
 
     // Opt In / Opt Out
     function setOptStatus(bool optOut) external payable;
@@ -52,8 +48,14 @@ interface IDigilToken is IERC721, IERC721Receiver {
     // ERC721 Receiver
     function onERC721Received(address operator, address from, uint256 tokenId, bytes calldata data) external override returns (bytes4);
 
+    // Reclaim Contribution
+    function reclaimContribution(uint256 tokenId) external payable;
+
+    // Vault Token
+    function vaultToken(address account, uint256 externalTokenId, bytes calldata data) external;
+
     // Recall Token
-    function recallToken(address account, uint256 tokenId) external;
+    function recallToken(address account, uint256 externalTokenId) external;
 
     // Token Information
     function tokenURI(uint256 tokenId) external view returns (string memory);
@@ -84,7 +86,7 @@ interface IDigilToken is IERC721, IERC721Receiver {
     function activateToken(uint256 tokenId) external returns (bool);
 
     // Deactivate Token
-    function deactivateToken(uint256 tokenId) external payable;
+    function deactivateToken(uint256 tokenId) external;
 
     // Link Token
     function linkToken(uint256 tokenId, uint256 linkId, uint8 efficiency) external payable;


### PR DESCRIPTION
### Motivation
- `IDigilToken` had diverged from the `DigilToken` implementation (stale events, removed/renamed functions and signature mismatches) which risks compilation and runtime integration errors.
- The goal is to make the interface exactly mirror the currently emitted events and external API of `DigilToken` so tests and integrations compile and rely on the true ABI. 

### Description
- Replaced `OptOut`/`OptIn` events with `OptStatus(address indexed account, bool optOut)` and removed stale `PendingDistribution` so events match the implementation. 
- Aligned `Buff` to the implementation signature `event Buff(uint256 indexed tokenId)` and added missing emitted events `Batch(uint256 indexed tokenId)` and `Prime(uint256 indexed tokenId)`. 
- Removed stale admin `sweep(address)` from the interface, removed the unused `IERC20` import, and updated function surface to match the implementation by adding `reclaimContribution(uint256)`, `vaultToken(address,uint256,bytes)`, renaming `recallToken` second parameter to `externalTokenId`, changing `withdraw()` to non-payable, and making `deactivateToken(uint256)` non-payable. 
- Updated `README.md` to document the new event surface and lifecycle/event notes (`OptStatus`, `Batch`, `Buff(tokenId)`, `Prime`).

### Testing
- Ran a Python event parity check comparing `contracts/IDigilToken.sol` and `contracts/DigilToken.sol` event declarations via a script: the parity check passed. 
- Ran a Python scan of all `tests/DigilToken*_test.sol` usages to ensure every `digil.<fn>()` call is provided by `IDigilToken` plus inherited `IERC721` methods: the scan passed. 
- Attempted to run `solc --version` and `forge --version` but both tools are not available in this environment, so full compilation and test runner execution could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5bee8bfc8326a520d1e185334e58)