### PR TITLE
Clarify exact `updateToken` msg.value requirement and add overpay revert test

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,13 @@ The final release dismantling the construct. First call requires owner/approved 
 - **Active Discharge**: Behaves like activation—ETH is settled proportionally. However, any remaining active power is forcefully pushed outward along the token's link graph, strengthening its neighbors before contributor/distribution state is cleared. Active discharge does **not** itself deactivate the Digil; call `deactivateToken(uint256 tokenId)` separately if you want it powered down.
 - **Wrapped NFT Recallability**: If this Digil wraps an external ERC721, an *inactive* discharge clears recallability; an *active* discharge preserves it (the external NFT remains vaulted until recalled).
 
+### Maintenance During Lifecycle
+`updateToken(uint256 tokenId, uint256 incrementalValue, uint256 activationThreshold, bytes data, string uri)`
+
+- When `uri` and `data` are both empty, `msg.value` must equal exactly `0`.
+- When either `uri` or `data` is non-empty, `msg.value` must equal exactly `max(currentIncrementalValue, newIncrementalValue, globalIncrementalValue)`.
+- Required ETH from this call is routed into the protocol value pool.
+
 ---
 
 ## Linking & Affinity
@@ -256,7 +263,7 @@ Accounts can willingly blacklist themselves via this function by paying a small 
 ## Admin & Security Notes
 
 - **Metadata Updates**: `updateToken(uint256 tokenId, uint256 incrementalValue, uint256 activationThreshold, bytes data, string uri)`  
-  Token URIs and internal arbitrary data can be updated by paying the required Coin cost and, when metadata/data is actually being changed, the required ETH amount based on the applicable incremental-value floor. Economic parameters are frozen only while the token currently has pending inactive `charge > 0`; if current charge is zero, they may be changed even if the token was used in an earlier lifecycle.
+  Token URIs and internal arbitrary data can be updated by paying the required Coin cost. When `uri` and `data` are both empty, `msg.value` must equal exactly `0`. When either `uri` or `data` is non-empty, `msg.value` must equal exactly `max(currentIncrementalValue, newIncrementalValue, globalIncrementalValue)`. Required ETH from this call is routed into the protocol value pool. Economic parameters are frozen only while the token currently has pending inactive `charge > 0`; if current charge is zero, they may be changed even if the token was used in an earlier lifecycle.
 - **Restriction Controls**: `restrictToken(uint256 tokenId, address[] whitelisted)` allows owners of restricted Digils to curate and update contributor access lists with explicit on-chain events.
 - **Read-Only Views**: The contract exposes various functions to allow front-ends to easily read the complex, packed state of any Digil:
   - `tokenCharge(uint256 tokenId)`

--- a/contracts/DigilToken.sol
+++ b/contracts/DigilToken.sol
@@ -1596,11 +1596,11 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
     ///           >= 5 to preserve planar affinity encoding.
     ///
     ///         ETH requirement:
-    ///         - If neither `uri` nor `data` is updated (both empty), no minimum ETH is required.
-    ///         - If either `uri` or `data` is updated, the call must include at least:
+    ///         - If neither `uri` nor `data` is updated (both empty), required ETH is exactly 0.
+    ///         - If either `uri` or `data` is updated, the call must send exactly:
     ///               minimumValue = max(t.incrementalValue, incrementalValue, _incrementalValue)
-    ///           The required ETH must be sent exactly, and is routed into the protocol value pool
-    ///           via {_addValue} rather than being stored directly on the token.
+    ///           The required ETH is routed into the protocol value pool via {_addValue}
+    ///           rather than being stored directly on the token.
     ///
     ///         State updates:
     ///         - Updates `t.incrementalValue` and `t.activationThreshold` after validation.

--- a/tests/DigilTokenC_test.sol
+++ b/tests/DigilTokenC_test.sol
@@ -117,4 +117,23 @@ contract CharlieTestSuite {
             Assert.ok(true, "Incorrect error for updating charged token");
         }
     }
+
+    /// #sender: account-2
+    /// #value: 500000000000000
+    function testUpdateTokenRejectsOverpayOnMetadataDataChange() external payable {
+        uint256 coinMultiplier = 10 ** 18;
+        bool approved = coins.approve(address(digil), 2 * 1000 * 100 * coinMultiplier);
+        Assert.ok(approved, "Coin approval failed");
+
+        uint256 tokenId = digil.createToken{value: 100000000000000}(100000000000000, 1000000000000000000, false, 4, "Overpay Test");
+
+        uint256 requiredValue = 200000000000000;
+        digil.updateToken{value: requiredValue}(tokenId, requiredValue, 1000000000000000000, "Updated Data", "Updated URI");
+
+        try digil.updateToken{value: requiredValue + 1}(tokenId, requiredValue, 1000000000000000000, "Overpay Data", "Overpay URI") {
+            Assert.ok(false, "Overpaying updateToken with metadata/data change should revert");
+        } catch {
+            Assert.ok(true, "Overpaying updateToken correctly reverted");
+        }
+    }
 }


### PR DESCRIPTION
### Motivation

- The `updateToken` implementation enforces `msg.value == minimumValue` but documentation used “at least” phrasing which could mislead integrators.  
- Align NatSpec and README wording with runtime behavior so callers know surplus ETH will revert when metadata/data are changed.  
- Add a test to lock in the expected revert behavior for overpayment during metadata/data updates.

### Description

- Updated the `updateToken` NatSpec in `contracts/DigilToken.sol` to state the `msg.value` requirement as an exact match (`0` when nothing changes; exact `max(...)` when `uri` or `data` change).  
- Updated `README.md` lifecycle and admin/security sections to use identical exact-match language and to note required ETH is routed into the protocol value pool.  
- Added a new Remix-style test `testUpdateTokenRejectsOverpayOnMetadataDataChange` in `tests/DigilTokenC_test.sol` that proves overpaying `msg.value` reverts when `data`/`uri` are changed.  
- No runtime logic was changed; only NatSpec, README text, and tests were added/modified.

### Testing

- Verified textual changes and presence of new test with `rg -n "updateToken|must equal exactly|must include at least" contracts/DigilToken.sol README.md tests/DigilTokenC_test.sol` which returned the updated locations.  
- Committed the changes locally with a commit message `Clarify exact updateToken ETH requirement and add overpay revert test`.  
- No Solidity test runner was executed in this environment (no Remix/Foundry test harness was invoked), so the new test is present but un-run here; it is a Remix-style test and should be executed in the repository's normal Remix/Remix Unit Testing environment to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5ca68cd88326bada22683742bd05)