### PR TITLE
Clarify planar alignment vs extended/admin plane docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,12 @@ At deployment, the contract mints **21 foundational planar tokens** to the admin
 - **Ethereal**: Aether, World
 - **Extended**: Virtual, ILXR
 
-End-user Digils may **align** to a foundational plane during creation. This alignment acts as a permanent hidden attribute that dictates how well your sigil resonates with others in the network.
+Only planes **1..18** are user-alignable during `createToken`.
+
+- **User-alignable planes (1..18)**: Void through World.
+- **Extended/admin planes (19..20)**: Virtual and ILXR; minted at deploy and reserved for extended/admin planar behavior.
+
+End-user Digils may **align** to a user-alignable foundational plane during creation. This alignment acts as a permanent hidden attribute that dictates how well your sigil resonates with others in the network.
 
 ---
 

--- a/contracts/DigilToken.sol
+++ b/contracts/DigilToken.sol
@@ -41,8 +41,8 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
     uint256 private _transferValue = 95 * VALUE_MULTIPLIER;     // The portion of incremental value distributed to users
 
     // Planar token policy
-    uint256 private constant PLANAR_MAX_ID = 18;                // Highest planar token ID that can be linked.
-    uint256 private constant PLANAR_TRANSFER_MAX_ID = 20;       // Highest planar token ID that can be transferred. The planar set is [0 .. PLANAR_TRANSFER_MAX_ID] inclusive.
+    uint256 private constant PLANAR_MAX_ID = 18;                // Highest user-alignable plane ID.
+    uint256 private constant PLANAR_TRANSFER_MAX_ID = 20;       // Highest minted/admin planar ID. The planar set is [0 .. PLANAR_TRANSFER_MAX_ID] inclusive.
     bool private _planarTransferActive;                         // When true, a temporary transfer window is open to move planar tokens from the current owner to the new owner during `transferOwnership`.
 
     // Batch operations limiter
@@ -1489,9 +1489,9 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
     ///                          all supplied ETH is added to the token's intrinsic value.
     /// @param  activationThreshold The number of coins required for token activation.
     /// @param  restricted Whether the token is restricted to whitelisted addresses for charging.
-    /// @param  plane The chosen planar token (numeric index) to link with. This becomes the immutable
-    ///               foundational plane for this token. Must be 0 (no plane) or in the planar range
-    ///               [1 .. PLANAR_MAX_ID]. Foundational planes cannot be linked or changed later.
+    /// @param  plane The chosen user-alignable plane ID. This becomes the immutable foundational
+    ///               plane for this token. Must be 0 (no plane) or in the user alignment range
+    ///               [1 .. PLANAR_MAX_ID]. Foundational plane choice cannot be changed later.
     /// @param  data Optional arbitrary data to store with the token.
     /// @return tokenId The ID of the newly created token.
     function createToken(uint256 incrementalValue, uint256 activationThreshold, bool restricted, uint256 plane, bytes calldata data) external payable returns(uint256) {


### PR DESCRIPTION
### Motivation
- Remove ambiguity about which planar tokens are selectable by users by distinguishing user-alignable planes from deploy-minted/administrative planes and making in-code and README wording consistent.

### Description
- Updated `README.md` to state that user-alignable planes are `1..18` and that planes `19..20` are extended/admin planes minted at deploy, and updated `contracts/DigilToken.sol` NatSpec/comments for `PLANAR_MAX_ID`, `PLANAR_TRANSFER_MAX_ID`, and the `createToken` `plane` parameter to use the terms "user-alignable" and "minted/admin" and to reference the `[1 .. PLANAR_MAX_ID]` range.

### Testing
- Ran `git diff -- README.md contracts/DigilToken.sol` and `git diff --check`, both succeeded; no runtime or Solidity tests were required because this change is documentation/comments-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0a8ca9bc8326bb5b1b86fbac4233)