### PR TITLE
Clarify README wording for link discount trigger semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,9 @@ The final release dismantling the construct. First call requires owner/approved 
 By calling `linkToken(uint256 tokenId, uint256 linkId, uint8 efficiency)`, you establish a flow of value between two Digils. The strength of this connection relies on **Planar Affinity**—how well the elemental nature of the source aligns with the destination (e.g., Fire to Air vs. Fire to Water).
 
 - Linking splits the required ETH evenly between the two tokens.
-- Creating links costs Coins. You receive an **Early-Link Discount** (50% off) for the first two new links on a token.
+- Creating links costs Coins. You receive an **Early-Link Discount** (50% off) when a new link leaves the token with **`<= 2` total stored links**.
+- A foundational plane alignment link (set during creation) **counts toward that stored-link total**.
+- Therefore, aligned tokens will usually get the early-link discount on **only their first peer-to-peer Digil link**.
 - You can unlink peer-to-peer Digils via `unlinkToken(uint256 tokenId, uint256 linkId)`, but foundational planar alignments chosen at creation are permanent.
 - Link quality combines base efficiency, temporary efficiency bonuses, and affinity bonuses from the planar matrix.
 


### PR DESCRIPTION
### Motivation
- Align README linking economics language with the contract semantics in `contracts/DigilToken.sol::_linkCoinCost` by making the early-link discount trigger condition explicit.

### Description
- Updated `README.md` (Linking & Affinity) to state the 50% early-link discount applies when a new link leaves the token with `<= 2` total stored links, to note a foundational plane link counts toward that total, and to explain the practical effect for aligned tokens.

### Testing
- Performed repository checks and validation commands: `rg` to locate `_linkCoinCost` references, `sed` to inspect `DigilToken.sol`, `nl` to view the README region, `git status --short`, and committed the change with `git commit`; all commands completed successfully; no Solidity tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0abefb4c8326abf073d9bb454cae)