### PR TITLE
clarify restriction controls, whitelist behavior, and cost implications

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,8 @@ Accounts can willingly blacklist themselves via this function by paying a small 
 
 - **Metadata Updates**: `updateToken(uint256 tokenId, uint256 incrementalValue, uint256 activationThreshold, bytes data, string uri)`  
   Token URIs and internal arbitrary data can be updated by paying the required Coin cost. When `uri` and `data` are both empty, `msg.value` must equal exactly `0`. When either `uri` or `data` is non-empty, `msg.value` must equal exactly `max(currentIncrementalValue, newIncrementalValue, globalIncrementalValue)`. Required ETH from this call is routed into the protocol value pool. Economic parameters are frozen only while the token currently has pending inactive `charge > 0`; if current charge is zero, they may be changed even if the token was used in an earlier lifecycle.
-- **Restriction Controls**: `restrictToken(uint256 tokenId, address[] whitelisted)` allows owners of restricted Digils to curate and update contributor access lists with explicit on-chain events.
+- **Restriction Controls**: Restriction management allows approved operators to manage a token’s restricted/open mode and contributor allowlist with explicit on-chain events. Switching from open to restricted mode may require ETH (`max(token.incrementalValue, globalIncrementalValue)`), while allowlist additions/removals do **not** charge DIGIL coin transfers.
+- **Whitelist Directionality**: In the current implementation, whitelist flags are one-way at storage level: once an address is marked whitelisted for a token, that mapping entry is not cleared by later `restrictToken` calls.
 - **Read-Only Views**: The contract exposes various functions to allow front-ends to easily read the complex, packed state of any Digil:
   - `tokenCharge(uint256 tokenId)`
   - `tokenData(uint256 tokenId)`
@@ -284,8 +285,8 @@ Accounts can willingly blacklist themselves via this function by paying a small 
 
 ## Economics & Costs Summary
 
-- **Operations costing ETH**: Creating restricted tokens, proxy-charging, establishing new links, updating metadata, overcharging, and reclaiming abandoned contributions.
-- **Operations costing Coins (DIGIL)**: Aligning with rare planar archetypes, linking to other nodes, applying temporary buffs, priming, stabilizing, vaulting external NFTs, and updating restricted contributor lists.
+- **Operations costing ETH**: Creating restricted tokens, proxy-charging, establishing new links, updating metadata, overcharging, reclaiming abandoned contributions, and switching a token from open mode into restricted mode.
+- **Operations costing Coins (DIGIL)**: Aligning with rare planar archetypes, linking to other nodes, applying temporary buffs, priming, stabilizing, and vaulting external NFTs. Restriction-list updates do not trigger DIGIL coin transfers.
 - **Operations that are free (gas only)**: Activating, Deactivating, unlinking, and standard internal transfers.
 
 *(Note: Exact values fluctuate based on the `configure` dials managed by the Digil Governor).*


### PR DESCRIPTION
### Motivation
- Clarify the on-chain semantics and economic effects of token restriction management so integrators and users understand when ETH or DIGIL are required.
- Explicitly document the current whitelist storage behavior to avoid incorrect assumptions about revocation when calling `restrictToken`.

### Description
- Rewrote the `Restriction Controls` documentation to state that approved operators can manage a token's open/restricted mode and contributor allowlist and that switching from open to restricted mode may require ETH equal to `max(token.incrementalValue, globalIncrementalValue)` while allowlist changes do not charge DIGIL coins.
- Added a `Whitelist Directionality` note that whitelist flags are one-way in storage and are not cleared by later `restrictToken` calls.
- Updated the `Operations costing ETH` and `Operations costing Coins (DIGIL)` lists to reflect that switching to restricted mode may cost ETH and that restriction-list updates do not trigger DIGIL transfers.

### Testing
- This change is documentation-only and did not modify contract code, so no automated unit tests were required or changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0ab2290083268b5bb69afb14551e)