### PR TITLE
Clarify checkpoint-cap terminology and withdraw bonus semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,9 +239,15 @@ Digils can act as "spirit vessels" for other NFTs.
 `withdraw()`
 
 When ETH or Coins are owed to you (from activation payouts, refunds, or system rewards), they sit in a pending distribution pool. Calling withdraw pulls these assets to your wallet.
-- **Time Bonuses**: If you hold any Digils, pending Coins accrue a time-based bonus every 15 minutes until a per-withdraw cap is reached (the accrual slope is sized using a 7-day yield denominator).
+- **Time Bonuses (Checkpoint-Based)**: If you hold Digils, each full 15-minute interval (`BONUS_INTERVAL`) since your last checkpoint adds 1% of your checkpoint cap, where `checkpoint cap = _coinRate + (balance * _coinMultiplier / YIELD_PERIOD)`. Accrual saturates at that checkpoint cap, then stops until the next checkpoint.
+- **Timer Reset Semantics**: `withdraw()` and qualifying ERC-721 balance updates both checkpoint yield. At each checkpoint, the timer resets to the current timestamp, so partial intervals are discarded and never carried forward.
 - **Single Settlement Surface**: Pending ETH and DIGIL from different flows (charging, activation, discharge, keeper rewards) are consolidated behind one user-level withdrawal path.
 - **Best-Effort Coin Payout**: Coin transfer is best-effort. If mint/transfer of DIGIL fails in the ERC20 path, `withdraw()` does not revert for that reason and can return `0` coins while still paying ETH.
+
+**Example (inside vs. outside one interval):**
+- Suppose your checkpoint cap is **500 DIGIL** and your last checkpoint was just set.
+- If you call `withdraw()` again after **10 minutes** (< 15 minutes), bonus from that call is **0** and the timer resets at that call.
+- If you then wait **20 minutes** and call `withdraw()` again, exactly **1** full interval has elapsed, so bonus is **1% of 500 = 5 DIGIL** (well below the 500 DIGIL checkpoint cap).
 
 ### Contributor Reclaim
 `reclaimContribution(uint256 tokenId)`

--- a/contracts/DigilToken.sol
+++ b/contracts/DigilToken.sol
@@ -572,10 +572,10 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
             uint256 intervals = (nowTs - oldTime) / BONUS_INTERVAL;
 
             if (intervals != 0 && balance != 0) {
-                uint256 dailyCap = _coinRate + (balance * _coinMultiplier / YIELD_PERIOD);
-                uint256 bonus = intervals * dailyCap / BONUS_RATE_DIVISOR;
+                uint256 checkpointCap = _coinRate + (balance * _coinMultiplier / YIELD_PERIOD);
+                uint256 bonus = intervals * checkpointCap / BONUS_RATE_DIVISOR;
 
-                d.coins += bonus < dailyCap ? bonus : dailyCap;
+                d.coins += bonus < checkpointCap ? bonus : checkpointCap;
             }
         }
 
@@ -600,13 +600,15 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
     ///         Collector-yield:
     ///         - Calling {withdraw} is itself a checkpoint. If fewer than
     ///           `BONUS_INTERVAL` seconds have elapsed since the previous checkpoint,
-    ///           no collector-yield is credited and the partial interval is discarded.
-    ///         - Yield is no longer calculated ad hoc only from the current balance
-    ///           at withdrawal time.
-    ///         - Instead, {_checkpointYield} is used both on transfers and on
-    ///           withdrawal.
-    ///         - This prevents temporary NFT concentration from applying an old
-    ///           timer to a newly increased balance.
+    ///           no collector-yield is credited and that partial interval is
+    ///           discarded because the timer is reset at checkpoint time.
+    ///         - For each full `BONUS_INTERVAL`, the account accrues 1% of its
+    ///           checkpoint cap (`_coinRate + balance * _coinMultiplier / YIELD_PERIOD`).
+    ///         - Accrual saturates at the checkpoint cap for that checkpoint.
+    ///         - `_checkpointYield` always resets the timer to `block.timestamp`,
+    ///           even when no bonus is accrued (including zero-balance checkpoints).
+    ///         - Yield is checkpoint-based (transfer/withdraw), preventing old elapsed
+    ///           time from being retroactively applied to a newly increased balance.
     ///
     ///         Coin payout behavior:
     ///         - If the contract does not hold enough Coins, it attempts to mint the


### PR DESCRIPTION
### Motivation
- Fix ambiguous wording that used "daily cap" for a checkpoint-based accrual model and make docs match the implemented `BONUS_INTERVAL` semantics.
- Ensure callers and integrators understand saturation and timer-reset behavior so there is no confusion about when bonus Coins accrue.

### Description
- Renamed the local variable in `_checkpointYield` from `dailyCap` to `checkpointCap` to reflect that bonuses are computed per-checkpoint, not daily. (`contracts/DigilToken.sol`)
- Reworded the `withdraw()` NatSpec to explicitly describe: full-interval accrual at `BONUS_INTERVAL`, 1% per full interval, checkpoint-cap saturation, and that `_checkpointYield` resets the timer at each checkpoint (including when no bonus is accrued). (`contracts/DigilToken.sol`)
- Updated `README.md` Withdrawals section to match the exact implementation, added a short example demonstrating a withdrawal inside a 15-minute interval (yields 0) and one outside it (yields 1% of checkpoint cap). (`README.md`)
- No runtime logic, ABI, or storage changes were made; only variable rename and documentation updates.

### Testing
- Searched source and docs for the old phrasing using `rg` and verified the previous "daily cap" phrasing was removed (no matches found).
- Ran `npx --yes prettier --check README.md` (initial check reported formatting warnings), then ran `npx --yes prettier --write README.md` and re-ran `npx --yes prettier --check README.md` which passed.
- Attempted `solc --version` and `forge --version` but both toolchain binaries were not available in this environment, so contract compilation and on-chain tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0b0fb1fc832691ee783fdacbf1aa)