### PR TITLE
Align README read-only views with IDigilToken and add interface coverage test

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,13 +281,13 @@ Accounts can willingly blacklist themselves via this function by paying a small 
 - **Restriction Controls**: Restriction management allows approved operators to manage a token’s restricted/open mode and contributor allowlist with explicit on-chain events. Switching from open to restricted mode may require ETH (`max(token.incrementalValue, globalIncrementalValue)`), while allowlist additions/removals do **not** charge DIGIL coin transfers.
 - **Whitelist Directionality**: In the current implementation, whitelist flags are one-way at storage level: once an address is marked whitelisted for a token, that mapping entry is not cleared by later `restrictToken` calls.
 - **Read-Only Views**: The contract exposes various functions to allow front-ends to easily read the complex, packed state of any Digil:
+  - `tokenURI(uint256 tokenId)`
   - `tokenCharge(uint256 tokenId)`
   - `tokenData(uint256 tokenId)`
   - `tokenBuff(uint256 tokenId)`
   - `tokenContribution(uint256 tokenId, address contributor)`
   - `tokenLinkAt(uint256 tokenId, uint256 index)`
   - `tokenAttachment(uint256 tokenId)`
-  - `configuration()`
 - **Lifecycle/Event ABI Notes**:
   - Batch lifecycle continuation emits `Batch(uint256 tokenId)` while activation/discharge are in progress.
   - Buff application emits `Buff(uint256 tokenId)`; buff parameters are read through `tokenBuff(uint256 tokenId)`.

--- a/tests/DigilTokenC_test.sol
+++ b/tests/DigilTokenC_test.sol
@@ -136,4 +136,61 @@ contract CharlieTestSuite {
             Assert.ok(true, "Overpaying updateToken correctly reverted");
         }
     }
+
+    /// #sender: account-2
+    /// #value: 100000000000000
+    function testReadOnlyViewSurfaceViaInterface() external payable {
+        uint256 tokenId = digil.createToken{value: 100000000000000}(100000000000000, 1000000000000000000, false, 4, "Read Surface");
+
+        string memory uri = digil.tokenURI(tokenId);
+        Assert.equal(uri, "", "Default token URI should be empty");
+
+        (uint256 charge, uint256 activeCharge, uint256 value, uint256 incrementalValue, uint256 activationThreshold) = digil.tokenCharge(tokenId);
+        Assert.equal(charge, 0, "New token charge should be 0");
+        Assert.equal(activeCharge, 0, "New token active charge should be 0");
+        Assert.equal(value, 100000000000000, "New token value should match creation ETH");
+        Assert.equal(incrementalValue, 100000000000000, "Incremental value should match creation input");
+        Assert.equal(activationThreshold, 1000000000000000000, "Activation threshold should match creation input");
+
+        (bool active, bool activating, bool discharging, bool restricted, uint256 links, uint256 contributors, uint256 contributionEpoch, uint256 distributionIndex, bytes memory data) = digil.tokenData(tokenId);
+        Assert.equal(active, false, "New token should be inactive");
+        Assert.equal(activating, false, "New token should not be activating");
+        Assert.equal(discharging, false, "New token should not be discharging");
+        Assert.equal(restricted, false, "Token should use open contribution mode");
+        Assert.equal(links, 1, "Plane alignment should reserve one link slot");
+        Assert.equal(contributors, 0, "New token should have no contributors");
+        Assert.equal(contributionEpoch, 0, "New token contribution epoch should start at 0");
+        Assert.equal(distributionIndex, 0, "New token distribution index should start at 0");
+        Assert.ok(keccak256("Read Surface") == keccak256(data), "Token data should match the creation payload");
+
+        (uint40 expiresAt, uint8 efficiencyBonus, uint8 attunement, uint8 amplification, uint16 flags, uint120 appearance) = digil.tokenBuff(tokenId);
+        Assert.equal(uint256(expiresAt), 0, "New token should not have an active buff");
+        Assert.equal(uint256(efficiencyBonus), 0, "Default efficiency bonus should be 0");
+        Assert.equal(uint256(attunement), 0, "Default attunement should be 0");
+        Assert.equal(uint256(amplification), 0, "Default amplification should be 0");
+        Assert.equal(uint256(flags), 0, "Default buff flags should be 0");
+        Assert.equal(uint256(appearance), 0, "Default buff appearance should be 0");
+
+        (uint256 contributionCharge, uint256 contributionDischarge, uint256 contributionValue, bool exists, bool whitelisted, uint256 epoch) = digil.tokenContribution(tokenId, address(this));
+        Assert.equal(contributionCharge, 0, "No contribution charge should exist for a fresh token");
+        Assert.equal(contributionDischarge, 0, "No contribution discharge should exist for a fresh token");
+        Assert.equal(contributionValue, 0, "No contribution value should exist for a fresh token");
+        Assert.equal(exists, false, "Fresh token should not have a contributor record");
+        Assert.equal(whitelisted, false, "Open token should not auto-whitelist contributors");
+        Assert.equal(epoch, 0, "Contributor epoch should default to 0");
+
+        (uint256 linkId, uint8 baseEfficiency, uint256 affinityBonus) = digil.tokenLinkAt(tokenId, 0);
+        Assert.equal(linkId, 4, "Plane alignment should be stored as the first link");
+        Assert.equal(uint256(baseEfficiency), 100, "Plane link should have default base efficiency of 100");
+        Assert.equal(affinityBonus, 0, "Plane link should initialize with zero affinity bonus");
+
+        (address contractTokenAddress, uint256 externalTokenId, bool recallable, bool vaulted) = digil.tokenAttachment(tokenId);
+        Assert.equal(contractTokenAddress, address(0), "Fresh token should not be attached to an external collection");
+        Assert.equal(externalTokenId, 0, "Fresh token should not have an external token id");
+        Assert.equal(recallable, false, "Fresh token should not be recallable");
+        Assert.equal(vaulted, false, "Fresh token should not be vaulted");
+
+        (bool ok, ) = address(digil).staticcall(abi.encodeWithSignature("configuration()"));
+        Assert.equal(ok, false, "configuration() should not be part of the read-only surface");
+    }
 }


### PR DESCRIPTION
### Motivation
- The README listed a stale `configuration()` read-view and omitted `tokenURI`, causing documentation ↔ interface drift for the public read surface.
- Ensure front-ends and tests rely on a single, authoritative read-only surface described in `IDigilToken`.

### Description
- Removed `configuration()` from the README “Read-Only Views” list and added `tokenURI(uint256 tokenId)` so the README matches `contracts/IDigilToken.sol`.
- Added `testReadOnlyViewSurfaceViaInterface` to `tests/DigilTokenC_test.sol` which exercises `tokenURI`, `tokenCharge`, `tokenData`, `tokenBuff`, `tokenContribution`, `tokenLinkAt`, and `tokenAttachment` via the `IDigilToken` interface and asserts a low-level `staticcall` to `configuration()` is not available.
- Small, documentation-and-test-only change with no protocol state or access-control modifications.

### Testing
- Ran `git diff --check` and recorded a clean result (success).
- Executed a parity check script (`python` snippet) that compared README read-methods against `contracts/IDigilToken.sol` and confirmed the lists match (success).
- Added a Remix-style Solidity test (`testReadOnlyViewSurfaceViaInterface`) to lock expected interface behavior; test is present in `tests/DigilTokenC_test.sol` and will run under the repository’s Remix test harness.
- Attempted `solc --version` but `solc` is not installed in this environment, so no local Solidity compilation/tests were executed here (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eff19d8c908326a8900c0074f2ec77)