### PR TITLE
Clarify proxy charging semantics and tighten transfer whitelist handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,8 @@ PR descriptions should include:
 - Verify value/coin costs documented for touched user-facing flows match implementation constants/logic.
 - Verify role/approval requirements in docs match access checks, ownership checks, and required approvals.
 - Verify lifecycle transitions and recallability rules in docs match reachable state transitions and constraints.
+- Verify `chargeToken` vs `chargeTokenAs` ETH floors are documented distinctly (proxy/sponsored charging has stricter ETH requirements).
+- Verify transfer-side behaviors that affect restriction UX (e.g., recipient auto-whitelisting) are reflected in docs/comments when relevant.
 
 ### Common drift risks
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ To empower the sigil, participants offer material value (ETH) and energetic valu
 - **Active Tokens**: If the token has no links, coins become "Kinetic Energy" (Active Charge). If the token is linked, the energy is distributed across the network based on the strength and affinity of those links. Unused ETH goes to the token's owner.
 - **Proxy Contribution Support**: `chargeTokenAs` allows sponsored or delegated contribution flows while preserving the canonical contributor ledger.
 - **Participation Definition**: In `chargeTokenAs`, participation means who receives contribution attribution (`contributor`), not who pays gas/calls. Both caller and contributor must be opted in (not blacklisted) for the charge to proceed.
+- **Proxy ETH Floor**: For sponsored/proxy charging (`contributor != msg.sender`), the call must provide at least `max(token.incrementalValue, globalIncrementalValue)` in ETH, even if `token.incrementalValue == 0`. By contrast, direct self-charging on a token with `token.incrementalValue == 0` can be done with `0` ETH.
 
 ### 3. Activating
 `activateToken(uint256 tokenId)`
@@ -282,6 +283,7 @@ Accounts can willingly blacklist themselves via this function by paying a small 
   Token URIs and internal arbitrary data can be updated by paying the required Coin cost. When `uri` and `data` are both empty, `msg.value` must equal exactly `0`. When either `uri` or `data` is non-empty, `msg.value` must equal exactly `max(currentIncrementalValue, newIncrementalValue, globalIncrementalValue)`. Required ETH from this call is routed into the protocol value pool. Economic parameters are frozen only while the token currently has pending inactive `charge > 0`; if current charge is zero, they may be changed even if the token was used in an earlier lifecycle.
 - **Restriction Controls**: Restriction management allows approved operators to manage a token’s restricted/open mode and contributor allowlist with explicit on-chain events. Switching from open to restricted mode may require ETH (`max(token.incrementalValue, globalIncrementalValue)`), while allowlist additions/removals do **not** charge DIGIL coin transfers.
 - **Whitelist Directionality**: In the current implementation, whitelist flags are one-way at storage level: once an address is marked whitelisted for a token, that mapping entry is not cleared by later `restrictToken` calls.
+- **Owner Auto-Whitelist on Transfer**: On mint/transfer, the recipient is automatically marked whitelisted for that token in the internal contributor mapping. This is intentional and persists across epochs.
 - **Read-Only Views**: The contract exposes various functions to allow front-ends to easily read the complex, packed state of any Digil:
   - `tokenURI(uint256 tokenId)`
   - `tokenCharge(uint256 tokenId)`

--- a/contracts/DigilToken.sol
+++ b/contracts/DigilToken.sol
@@ -871,10 +871,7 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
 
         t.lastActivity = block.timestamp;
         // Auto-whitelist the current owner address for future restricted charging.
-        // Skip burn path (`to == address(0)`) to avoid writing meaningless whitelist state.
-        if (to != address(0)) {
-            t.contributions[to].whitelisted = true;
-        }
+        t.contributions[to].whitelisted = true;
 
         return from;
     }

--- a/contracts/DigilToken.sol
+++ b/contracts/DigilToken.sol
@@ -870,7 +870,11 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
         address from = super._update(to, tokenId, auth);
 
         t.lastActivity = block.timestamp;
-        t.contributions[to].whitelisted = true;
+        // Auto-whitelist the current owner address for future restricted charging.
+        // Skip burn path (`to == address(0)`) to avoid writing meaningless whitelist state.
+        if (to != address(0)) {
+            t.contributions[to].whitelisted = true;
+        }
 
         return from;
     }
@@ -2029,9 +2033,10 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
 
     /// @notice Charges a token.
     ///         Requires a value sent greater than or equal to the token's incremental value for each coin.
-    ///         If token.incrementalValue == 0, charging does not require ETH; any ETH sent is treated as surplus value
-    ///         (credited as token value or distributed per the active/inactive path). If token.incrementalValue > 0,
-    ///         ETH must satisfy the per-charge minimum derived from incrementalValue.
+    ///         If token.incrementalValue == 0, direct charging (`chargeToken`) does not require ETH;
+    ///         any ETH sent is treated as surplus value (credited as token value or distributed per
+    ///         the active/inactive path). If token.incrementalValue > 0, ETH must satisfy the
+    ///         per-charge minimum derived from incrementalValue.
     /// @param  tokenId The token ID to charge.
     /// @param  coins The number of coin units to use.
     /// @return True if the token was successfully charged.
@@ -2045,9 +2050,12 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
     /// @dev    Requires that both the caller and `contributor` are not blacklisted,
     ///         and the token exists. Participation attribution is based on
     ///         `contributor`.
-    ///         If token.incrementalValue == 0, charging does not require ETH; any ETH sent is treated as surplus value
-    ///         (credited as token value or distributed per the active/inactive path). If token.incrementalValue > 0,
-    ///         ETH must satisfy the per-charge minimum derived from incrementalValue.
+    ///         Proxy contributions (`contributor != msg.sender`) always require at least one
+    ///         incremental-value unit of ETH:
+    ///             max(token.incrementalValue, globalIncrementalValue).
+    ///         This sponsored-charge floor applies even when token.incrementalValue == 0.
+    ///         For self-attributed charging (`contributor == msg.sender`), ETH minimum is derived
+    ///         from token.incrementalValue as documented on {chargeToken}.
     /// @param  contributor The address contributing the charge.
     /// @param  tokenId The token ID to charge.
     /// @param  coins The coin units used in the charge.


### PR DESCRIPTION
### Motivation
- Fix documentation/implementation drift observed around ETH requirements for direct vs proxy charging so integrators and relayers have correct expectations.
- Avoid unnecessary storage writes on token burn and make transfer-side whitelist behavior explicit for UX/maintenance clarity.

### Description
- Added a guard in `_update` to skip auto-whitelisting when `to == address(0)` so burn paths do not write meaningless whitelist state (file: `contracts/DigilToken.sol`).
- Clarified NatSpec on `chargeToken` and `chargeTokenAs` to document that sponsored/proxy charges (`contributor != msg.sender`) require at least `max(token.incrementalValue, globalIncrementalValue)` ETH even when `token.incrementalValue == 0` (file: `contracts/DigilToken.sol`).
- Updated `README.md` to reflect the proxy ETH floor and to call out the recipient auto-whitelist-on-transfer behavior so docs match runtime semantics.
- Updated `AGENTS.md` to add doc-parity checks that future changes must verify the `chargeToken` vs `chargeTokenAs` ETH-floor divergence and transfer-side auto-whitelisting behavior.

### Testing
- Performed repository inspections and diffs (`git diff -- AGENTS.md README.md contracts/DigilToken.sol`) to review the exact changes and scope; inspection succeeded.
- Attempted to run the Solidity compiler (`solc --version`) but the environment lacks `solc`, so no compile or automated Solidity tests were executed in this session.
- Static code review and targeted grep/line inspections were used to validate the edits and ensure no ABI or event signature changes were made; no automated test failures were observed because tests were not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f10f49f1908326ac14c2fd22455994)