### PR TITLE
Sync README: document Buff event for priming/stabilization/temporary buffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,8 +294,7 @@ Accounts can willingly blacklist themselves via this function by paying a small 
   - `tokenAttachment(uint256 tokenId)`
 - **Lifecycle/Event ABI Notes**:
   - Batch lifecycle continuation emits `Batch(uint256 tokenId)` while activation/discharge are in progress.
-  - Buff application emits `Buff(uint256 tokenId)`; buff parameters are read through `tokenBuff(uint256 tokenId)`.
-  - Priming emits `Prime(uint256 tokenId)`.
+  - Priming, stabilization, and temporary buff changes emit `Buff(uint256 tokenId)`; consumers should query `tokenBuff(uint256 tokenId)` to interpret the active buff state.
 - **Batch Safety**: Sensitive lifecycle transitions are protected by batch-locks. If a token is mid-activation, it cannot be transferred, charged, or updated until the community finishes the batch processing.
 
 ---


### PR DESCRIPTION
### Motivation
- Keep the README’s lifecycle ABI notes aligned with `contracts/DigilToken.sol` by removing the outdated `Prime(uint256 tokenId)` claim and documenting that priming, stabilization, and temporary buff changes use the unified `Buff(uint256 tokenId)` event.

### Description
- Replaced the `Lifecycle/Event ABI Notes` lines in `README.md` to state that priming, stabilization, and temporary buff changes emit `Buff(uint256 tokenId)` and that consumers should read `tokenBuff(uint256 tokenId)` to interpret buff state.

### Testing
- Ran `git diff -- README.md` and `rg -n "Lifecycle/Event ABI Notes|Buff\(uint256 tokenId\)|Prime\(uint256 tokenId\)|tokenBuff\(uint256 tokenId\)" README.md contracts/DigilToken.sol` to verify the change and parity with the contract, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f121d784108326a87e71ca25ad56a9)