### PR TITLE
Enforce uint128 bounds for reward caps and document safe casts

### DIFF
--- a/contracts/DigilCoin.sol
+++ b/contracts/DigilCoin.sol
@@ -273,10 +273,10 @@ contract DigilCoin is ERC20, ERC20Burnable, ERC20Pausable, AccessControl, ERC20P
         uint256 maxMultBps = uint256(BASE_BPS) + uint256(_maxActiveDays) * uint256(_dayBonusBps);
         if (maxMultBps > 50_000) revert BadParameters(); // hard cap: 5.0x effective multiplier
 
-        if (
-            _dailyCap == 0 || _epochCap == 0 || _dailyCap > _epochCap || _dailyCap > type(uint128).max
-                || _epochCap > type(uint128).max
-        ) revert BadParameters();
+        if (_dailyCap == 0 || _epochCap == 0 || _dailyCap > _epochCap ||
+            _dailyCap > type(uint128).max || _epochCap > type(uint128).max) {
+            revert BadParameters();
+        }
 
         _syncEpoch(); // ensure we are configuring for future epochs, not a stale "current" one
 

--- a/contracts/DigilCoin.sol
+++ b/contracts/DigilCoin.sol
@@ -273,7 +273,10 @@ contract DigilCoin is ERC20, ERC20Burnable, ERC20Pausable, AccessControl, ERC20P
         uint256 maxMultBps = uint256(BASE_BPS) + uint256(_maxActiveDays) * uint256(_dayBonusBps);
         if (maxMultBps > 50_000) revert BadParameters(); // hard cap: 5.0x effective multiplier
 
-        if (_dailyCap == 0 || _epochCap == 0 || _dailyCap > _epochCap) revert BadParameters();
+        if (
+            _dailyCap == 0 || _epochCap == 0 || _dailyCap > _epochCap || _dailyCap > type(uint128).max
+                || _epochCap > type(uint128).max
+        ) revert BadParameters();
 
         _syncEpoch(); // ensure we are configuring for future epochs, not a stale "current" one
 
@@ -565,7 +568,9 @@ contract DigilCoin is ERC20, ERC20Burnable, ERC20Pausable, AccessControl, ERC20P
         uint256 counted = _min3(amount, dailyRemain, epochRemain);
         if (counted == 0) return;
 
-        // Update counted spend counters
+        // Update counted spend counters.
+        // Safe casts: caps are bounded to uint128 in `setRewardParameters`, and `counted`
+        // is clamped by both remaining caps, so each sum cannot exceed uint128 max.
         ue.countedDaySpend = uint128(uint256(ue.countedDaySpend) + counted);
         ue.countedEpochSpend = uint128(uint256(ue.countedEpochSpend) + counted);
 


### PR DESCRIPTION
### Motivation
- Ensure `_dailyCap` and `_epochCap` configurations always fit into the `uint128` storage used by `UserEpoch.countedDaySpend` and `UserEpoch.countedEpochSpend` to avoid unsafe casts or misconfiguration that could corrupt accrual accounting.

### Description
- Add bounds checks in `setRewardParameters` to reject `_dailyCap` and `_epochCap` values greater than `type(uint128).max` in addition to existing non-zero and ordering checks.
- Add explanatory comments in `_recordEligibleSpend` next to the casts into `ue.countedDaySpend` and `ue.countedEpochSpend` stating the casts are safe because caps are validated and `counted` is clamped by remaining caps.
- Preserve existing accrual logic and emitted events (no change to math or public API besides the additional validation). 

### Testing
- Ran `npx prettier --check contracts/DigilCoin.sol`, which failed in this environment due to the Solidity parser/plugin for the formatter being unavailable. 
- Ran `solc --version`, which failed because `solc` is not installed in the environment, so compilation could not be performed here. 
- No Solidity unit tests were executed in this environment due to the missing toolchain; recommend running the repository test matrix (`tests/DigilCoin_test.sol` and related suites) and a full `solc` compile in CI before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f174b54f448326b20683f09237f9a2)