### PR TITLE
Document createToken ETH floor behavior in README and NatSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ The existence of a Digil follows a defined path: **Creating** â†’ **Charging** â
 
 You bring a Digil into existence by defining its required ETH increment and its activation threshold. You can choose to align it with a foundational plane (for an upfront coin fee) and choose whether it accepts open contributions or is restricted to a whitelist. Any ETH sent during creation becomes its foundational value.
 
+Creation ETH minimums are explicit:
+- Base required ETH is always at least the global `_incrementalValue` floor.
+- If `restricted == true` and `incrementalValue > global floor`, required ETH becomes that higher `incrementalValue`.
+- If `restricted == false`, setting a higher per-token `incrementalValue` does **not** raise the creation minimum above the global floor (it still affects later charging requirements).
+
 ### 2. Charging
 `chargeToken(uint256 tokenId, uint256 coins)`  
 `chargeTokenAs(address contributor, uint256 tokenId, uint256 coins)`
@@ -302,7 +307,11 @@ Accounts can willingly blacklist themselves via this function by paying a small 
 
 ## Economics & Costs Summary
 
-- **Operations costing ETH**: Creating restricted tokens, proxy-charging, establishing new links, updating metadata, overcharging, reclaiming abandoned contributions, and switching a token from open mode into restricted mode.
+- **Operations costing ETH**: Token creation (always at least global `_incrementalValue`; restricted tokens may require higher), proxy-charging, establishing new links, updating metadata, overcharging, reclaiming abandoned contributions, and switching a token from open mode into restricted mode.
+- **Creation ETH floor logic**:
+  - Base minimum: `msg.value >= global _incrementalValue`.
+  - Restricted token override: if `restricted == true` and `incrementalValue > global _incrementalValue`, then `msg.value >= incrementalValue`.
+  - Unrestricted token behavior: higher per-token `incrementalValue` does not increase the creation minimum, but it can increase ETH required in later charge flows.
 - **Link ETH requirement formula**: For `linkToken(source, destination, efficiency)`, minimum ETH is:
   - `source.incrementalValue + destination.incrementalValue`.
   - Sent ETH is split between the two linked tokens (`floor(value/2)` to source, remainder to destination).

--- a/contracts/DigilToken.sol
+++ b/contracts/DigilToken.sol
@@ -1490,6 +1490,10 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
     ///
     /// @param  incrementalValue The incremental value (in wei) required with each coin used for charging.
     ///                          Must be 0 or at least the global minimum incremental value.
+    ///                          Creation always requires at least the global floor (`_incrementalValue`).
+    ///                          If `restricted == true` and this value is higher than the global floor,
+    ///                          creation requires at least this higher value; otherwise unrestricted
+    ///                          creation keeps the global floor minimum even when this value is higher.
     ///                          Token creation accepts excess ETH above the minimum required deposit;
     ///                          all supplied ETH is added to the token's intrinsic value.
     /// @param  activationThreshold The number of coins required for token activation.


### PR DESCRIPTION
### Motivation
- Remove ambiguity about the minimum ETH required when creating tokens by documenting on-chain `createToken` semantics for restricted vs unrestricted tokens.
- Ensure README and function NatSpec are consistent with the implemented `createToken` checks that start from the global `_incrementalValue` floor and only raise the creation minimum for restricted tokens when a higher per-token `incrementalValue` is supplied.
- Keep the change minimal and non-invasive by updating only docs and NatSpec comments without changing runtime logic.

### Description
- Updated `README.md` "Creating" section to state that the base required ETH is always at least the global `_incrementalValue`, that restricted tokens require `incrementalValue` when it exceeds the global floor, and that unrestricted tokens do not raise the creation minimum above the global floor (while still affecting later charging).
- Added a concise bullet in `README.md` -> "Economics & Costs Summary" describing the creation ETH floor logic in explicit terms and showing the `msg.value` inequalities.
- Added matching NatSpec lines to `contracts/DigilToken.sol`'s `createToken` parameter docs to reflect the same restricted/unrestricted creation minimum semantics.

### Testing
- Ran `git diff -- README.md contracts/DigilToken.sol` to review changes and confirmed the updated diffs were present and as intended (succeeded).
- Printed and inspected context with `nl -ba README.md | sed -n '132,165p'`, `nl -ba README.md | sed -n '300,335p'`, and `nl -ba contracts/DigilToken.sol | sed -n '1488,1525p'` to verify the inserted documentation and NatSpec (succeeded).
- No unit or integration tests were required or modified since this is a documentation/NatSpec-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f17a6c581483268edf44383750294f)