### PR TITLE
Document activation/discharge sequencing and vault recallability semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ Once an inactive token reaches its activation threshold, it can be activated (fi
 - Contributors only receive a proportional ETH distribution if there is distributable surplus value in the token.
 - If there are many contributors, this processes in batches. Anyone can step in to pay gas and finish a batch, earning a **keeper bounty** in DIGIL for doing so.
 
+**Activation timeline (permission split):**
+- **Step A — First call (`activating == false`)**: only owner/approved operator can start activation; token must satisfy threshold and be inactive.
+- **Step B — Mid-batch (`activating == true`)**: any non-blacklisted address can submit continuation calls.
+- **Step C — Completion**: final continuation call flips token to active, clears activation lock, and consumes PRIMED if present.
+
+
 ### 4. Deactivating
 `deactivateToken(uint256 tokenId)`
 
@@ -172,6 +178,13 @@ The final release dismantling the construct. First call requires owner/approved 
 - **Inactive Discharge**: Contributors receive a full refund of their ETH and Coins. The owner gets any leftover value.
 - **Active Discharge**: Behaves like activation—ETH is settled proportionally. However, any remaining active power is forcefully pushed outward along the token's link graph, strengthening its neighbors before contributor/distribution state is cleared. Active discharge does **not** itself deactivate the Digil; call `deactivateToken(uint256 tokenId)` separately if you want it powered down.
 - **Wrapped NFT Recallability**: If this Digil wraps an external ERC721, an *inactive* discharge clears recallability; an *active* discharge preserves it (the external NFT remains vaulted until recalled).
+
+**Discharge timeline (fee + continuation):**
+- **Step A — First call (`discharging == false`)**: only owner/approved operator can start; caller must send **exactly** `max(globalIncrementalValue, tokenIncrementalValue) * max(1, links.length)` ETH.
+- **Step B — Mid-batch (`discharging == true`)**: any non-blacklisted address can continue processing.
+- **Step C — Continuations fee rule**: every continuation call must send **exactly `0` ETH**.
+- **Step D — Completion**: lock clears; contributors are fully settled for that epoch; temporary buff fields are reset while persisted appearance payload remains.
+
 
 ### Maintenance During Lifecycle
 `updateToken(uint256 tokenId, uint256 incrementalValue, uint256 activationThreshold, bytes data, string uri)`
@@ -244,6 +257,14 @@ Digils can act as "spirit vessels" for other NFTs.
   - **Recall fully vaulted NFT**: If the NFT is fully vaulted, an approved operator of the wrapping Digil can recall it only when the attachment is currently marked recallable.
 - **Recallability Rules**: Recallability is enforced through the attachment's stored `recallable` flag. For vaulted wrappers, that flag is updated during the wrapper's lifecycle processing and can become true under the normal zero-threshold activation/distribution path. It stays sticky across deactivation, and is cleared only when either (a) recall succeeds, or (b) a full discharge settles while the Digil is inactive.
 - **Post-Recall Behavior**: Recalling transfers the external NFT to the current Digil owner, applies active-charge bleed to the Digil shell, and preserves attachment provenance metadata for historical indexing.
+
+**Recallability transition timeline (pending vs fully vaulted):**
+- **Pending vault** (`_contractTokenAddresses != address(0)` and `!= address(this)`): NFT is deposited but not wrapped; depositor can cancel via `recallToken`; recallability flag is not the gate here.
+- **Fully vaulted + not recallable** (`_contractTokenAddresses == address(this)` and `recallable == false`): wrapper exists, but recall is blocked.
+- **Fully vaulted + recallable** (`_contractTokenAddresses == address(this)` and `recallable == true`): approved wrapper operator can execute recall.
+- **After successful recall**: vault ownership mapping clears to unvaulted, `recallable` is cleared, and provenance fields on the Digil shell stay populated.
+- **After inactive full discharge of wrapper**: attachment recallability is cleared even though provenance metadata remains for indexing.
+
  
 
 ---
@@ -258,6 +279,13 @@ When ETH or Coins are owed to you (from activation payouts, refunds, or system r
 - **Timer Reset Semantics**: `withdraw()` and qualifying ERC-721 balance updates both checkpoint yield. At each checkpoint, the timer resets to the current timestamp, so partial intervals are discarded and never carried forward.
 - **Single Settlement Surface**: Pending ETH and DIGIL from different flows (charging, activation, discharge, keeper rewards) are consolidated behind one user-level withdrawal path.
 - **Best-Effort Coin Payout**: Coin transfer is best-effort. If mint/transfer of DIGIL fails in the ERC20 path, `withdraw()` does not revert for that reason and can return `0` coins while still paying ETH.
+
+### Known Operational Caveats
+
+- **Best-effort DIGIL payout**: `withdraw()` prioritizes preserving ETH settlement success. If DIGIL mint/transfer cannot complete, coin pending balances are restored for retry and the call can still succeed for ETH payout.
+- **Operator UX implication**: frontends/indexers should treat `(coins == 0, value > 0)` from `withdraw()` as a possible soft coin-payout failure rather than assuming no pending coin entitlement existed.
+- **Retry behavior**: users can call `withdraw()` again later when DIGIL transfer conditions recover; this does not require replaying prior lifecycle operations.
+
 
 **Example (inside vs. outside one interval):**
 - Suppose your checkpoint cap is **500 DIGIL** and your last checkpoint was just set.

--- a/contracts/DigilToken.sol
+++ b/contracts/DigilToken.sol
@@ -619,6 +619,12 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
     ///             * returned `coins` is 0.
     ///         - This preserves the existing best-effort Coin payout model.
     ///
+    ///         State before/after:
+    ///         - Before: `distribution.value` / `distribution.coins` may hold pending payouts.
+    ///         - After: ETH pending is always zeroed before transfer attempt.
+    ///         - After: Coin pending is zeroed only for non-opted-out users; on soft Coin
+    ///           payout failure, the pending amount is restored.
+    ///
     /// @return coins The number of Coin units successfully transferred to the sender.
     /// @return value The native ETH value transferred to the sender.
     function withdraw() external nonReentrant returns (uint256 coins, uint256 value) {
@@ -1081,6 +1087,11 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
     ///    Any later recallability is governed by the attachment's stored `recallable` flag,
     ///    which is updated during distribution processing elsewhere in the lifecycle.
     ///
+    ///  State before/after:
+    ///  - Before: external NFT is pending with a depositor marker in `_contractTokenAddresses`.
+    ///  - After: marker becomes `address(this)`, reverse index is populated, and wrapper
+    ///    provenance fields are initialized on the Digil shell.
+    ///
     /// @param  account The external ERC721 contract address.
     /// @param  externalTokenId The external ERC721 tokenId being vaulted.
     /// @param  data    Optional data to store with the newly minted Digil token.
@@ -1156,6 +1167,14 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
     ///  - Interaction:
     ///      * Transfers the external ERC721 back to the current Digil owner:
     ///          IERC721(account).safeTransferFrom(address(this), ownerOf(digilTokenId), externalTokenId, t.data)
+    ///
+    ///
+    ///  State before/after:
+    ///  - Before (pending cancel): holder marker equals depositor.
+    ///  - After (pending cancel): holder marker and reverse index are cleared.
+    ///  - Before (fully vaulted recall): holder marker is `address(this)` and `recallable` gates exit.
+    ///  - After (successful recall): holder marker and `recallable` clear, while attachment provenance
+    ///    fields remain sticky on the Digil for historical indexing.
     ///
     /// @param  account          The external ERC721 contract address.
     /// @param  externalTokenId  The external ERC721 tokenId to cancel/recall.
@@ -2337,6 +2356,12 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
     ///         settles contributions and redistributes value/active charge according
     ///         to the protocol rules.
     ///
+    ///         State before/after:
+    ///         - Before first call: requires owner/approved caller, not activating, and first-call fee.
+    ///         - Mid-cycle: `discharging == true` allows continuation by any non-blacklisted caller with 0 ETH.
+    ///         - After completion: `discharging == false`, epoch advances, temporary buff fields are cleared,
+    ///           and persisted appearance/attachment provenance fields remain.
+    ///
     /// @param  tokenId The token ID to discharge.
     /// @return completed True if this call finished the discharge; false if more
     ///                   calls are required to process remaining contributors.
@@ -2477,6 +2502,11 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
     ///
     ///         No Ether is required for activation itself; all ETH-related costs occur
     ///         during charging and other value-manipulating operations.
+    ///
+    ///         State before/after:
+    ///         - Before first call: token must be inactive and not discharging.
+    ///         - Mid-cycle: `activating == true` allows continuation by any non-blacklisted caller.
+    ///         - After completion: `active == true`, `activating == false`, and PRIMED is consumed if set.
     ///
     /// @param  tokenId The ID of the token to activate.
     /// @return completed True if this call finished the activation; false if more


### PR DESCRIPTION
### Motivation
- Clarify multi-transaction permissioning and continuation semantics for activation and discharge to reduce operator/UX ambiguity. 
- Make vault/recall transitions and attachment provenance explicit so indexers and integrators can reason about pending vs fully-vaulted flows. 
- Surface the existing best-effort DIGIL payout behavior so frontends/operators can handle ETH-success / coin-soft-failure outcomes properly.

### Description
- Added explicit timeline bullets in `README.md` for activation permission split (first-call owner/approved vs open continuations) and activation lifecycle completion. 
- Added explicit timeline bullets in `README.md` for discharge sequencing including required first-call fee `max(globalIncrementalValue, tokenIncrementalValue) * max(1, links.length)` and zero-ETH continuation requirement. 
- Added `README.md` recallability transition timeline for pending vs fully-vaulted states and a new `Known Operational Caveats` subsection describing best-effort coin payout and retry UX. 
- Mirrored these semantics in NatSpec comments in `contracts/DigilToken.sol` for `withdraw`, `vaultToken`, `recallToken`, `dischargeToken`, and `activateToken`, including explicit “state before/after” notes and sticky provenance remarks; no runtime logic was changed.

### Testing
- Verified changes were staged and committed with `git status --short` and `git commit` (commit message: "Document activation/discharge sequencing and vault recallability semantics").
- Searched and validated the inserted documentation strings with `rg -n "Activation timeline|Discharge timeline|Recallability transition timeline|Known Operational Caveats|State before/after" README.md contracts/DigilToken.sol` and confirmed presence. 
- No Solidity compilation or unit tests were executed because this PR is documentation/NatSpec-only and contains no behavioral code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ba1a1c4c832698ac99d942bb1566)