### PR TITLE
Clarify externalTokenId meaning in vault/recall docs and NatSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,8 +236,8 @@ Digils can act as "spirit vessels" for other NFTs.
 
 - **Step 1 — Pending Deposit**: Transfer an external ERC-721 into `DigilToken` via `safeTransferFrom`. This records the depositor as the pending owner for that `(externalCollection, externalTokenId)` pair.
 - **Deposit Mode Requirement**: Only `safeTransferFrom` deposits are supported; direct safe-mint to DigilToken is rejected.
-- **Step 2 — Finalize Vault**: `vaultToken(address account, uint256 tokenId, bytes data)`  
-  Only the recorded depositor can finalize. Finalization charges the Coin vault fee, mints a new Digil wrapper, marks the external NFT as fully vaulted, and stores a reverse index from `(account, externalTokenId)` to the minted Digil id. The wrapper is created with an activation threshold of `0`.
+- **Step 2 — Finalize Vault**: `vaultToken(address account, uint256 externalTokenId, bytes data)`  
+  Only the recorded depositor can finalize. Finalization charges the Coin vault fee, mints a new Digil wrapper, marks the external NFT as fully vaulted, and stores a reverse index from `(account, externalTokenId)` to the minted Digil id. The wrapper is created with an activation threshold of `0`. `externalTokenId` refers to the deposited token ID from the external ERC721 collection (`account`), not a Digil token ID.
 - **Unified Exit / Recall**: `recallToken(address account, uint256 externalTokenId)`  
   This function now handles both flows:
   - **Cancel pending deposit**: If the NFT is still pending (not fully vaulted), only the depositor can cancel and receive the NFT back.

--- a/contracts/DigilToken.sol
+++ b/contracts/DigilToken.sol
@@ -1082,7 +1082,7 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
     ///    which is updated during distribution processing elsewhere in the lifecycle.
     ///
     /// @param  account The external ERC721 contract address.
-    /// @param  externalTokenId The external ERC721 tokenId being vaulted.
+    /// @param  externalTokenId The deposited token ID from the external ERC721 collection (`account`), not a Digil token ID.
     /// @param  data    Optional data to store with the newly minted Digil token.
     function vaultToken(address account, uint256 externalTokenId, bytes calldata data) external nonReentrant {
         address user = _msgSender();
@@ -1158,7 +1158,7 @@ contract DigilToken is ERC721, Ownable, IERC721Receiver, ReentrancyGuard {
     ///          IERC721(account).safeTransferFrom(address(this), ownerOf(digilTokenId), externalTokenId, t.data)
     ///
     /// @param  account          The external ERC721 contract address.
-    /// @param  externalTokenId  The external ERC721 tokenId to cancel/recall.
+    /// @param  externalTokenId  The deposited token ID from the external ERC721 collection (`account`), not a Digil token ID.
     function recallToken(address account, uint256 externalTokenId) external nonReentrant {
         address caller = _msgSender();
 


### PR DESCRIPTION
### Motivation
- Make the vaulting and recall documentation explicit that `externalTokenId` refers to the token ID from the external ERC-721 contract (the deposited token), not a Digil token ID, to avoid confusion when finalizing or recalling vaults.

### Description
- Updated `README.md` and the NatSpec comments in `contracts/DigilToken.sol` to clarify the meaning of `externalTokenId` in the `vaultToken` and `recallToken` flows and to ensure the parameter is clearly documented as the deposited token ID from the external ERC-721 collection.

### Testing
- Compiled the contract and ran the project test suite (`npx hardhat compile` and `npx hardhat test`); the compilation and tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b800aa488326a1b186ac8324520e)