### PR TITLE
Tighten validation for spend weights, lock arithmetic, and staking

### DIFF
--- a/contracts/DigilCoin.sol
+++ b/contracts/DigilCoin.sol
@@ -248,12 +248,15 @@ contract DigilCoin is ERC20, ERC20Burnable, ERC20Pausable, AccessControl, ERC20P
     /// @dev
     /// - `weightBps == 0` disables eligibility for that spender.
     /// - `weightBps` is applied to counted spend as: `deltaPoints = countedSpend * weightBps`.
-    /// - `spender` must be a deployed contract (`spender.code.length > 0`).
+    /// - Enabling a non-zero weight requires `spender` to be a deployed contract
+    ///   (`spender.code.length > 0`), but disabling remains possible after code changes
+    ///   or selfdestructs so stale allowlist entries can always be removed.
     /// - Eligibility *also* requires `msg.sender == spender` so arbitrary user transfers do not earn points.
     /// @param spender The deployed contract address that will be eligible to earn rewards for users who spend into it.
-    /// @param weightBps Weight in basis points, must be <= 10,000.
+    /// @param weightBps Weight in basis points, must be <= 10,000. Use 0 to disable an existing entry.
     function setSpendWeight(address spender, uint16 weightBps) external onlyRole(CONFIG_ROLE) {
-        if (spender == address(0) || spender.code.length == 0 || weightBps > BASE_BPS) revert BadParameters();
+        if (spender == address(0) || weightBps > BASE_BPS) revert BadParameters();
+        if (weightBps != 0 && spender.code.length == 0) revert BadParameters();
         spendWeightBps[spender] = weightBps;
         emit SpenderWeightSet(spender, weightBps);
     }

--- a/contracts/DigilGovernor.sol
+++ b/contracts/DigilGovernor.sol
@@ -101,8 +101,9 @@ contract DigilGovernor is Governor, GovernorStorage, GovernorVotes, GovernorTime
     event Burn(uint256 indexed proposalId, uint256 amount);
 
     // Errors
-    /// @notice Thrown when vote params are missing (tokenId is required for NFT-gated voting)
-    ///         or when a lock operation would overflow the checkpointed locked amount type (uint208)
+    /// @notice Thrown when vote params are missing (tokenId is required for NFT-gated voting),
+    ///         a lock operation would overflow the checkpointed locked amount type (uint208),
+    ///         or a staking amount is zero.
     error InvalidParams();
     /// @notice Thrown when the same NFT tokenId is reused on the same proposal.
     error AlreadyUsedNft(uint256 tokenId);
@@ -401,8 +402,12 @@ contract DigilGovernor is Governor, GovernorStorage, GovernorVotes, GovernorTime
         uint208 newAmount = currentAmount;
         if (amount > 0) {
             // Guard: amount must fit in uint208, and currentAmount + amount must not overflow uint208.
-            if (amount > type(uint208).max) revert InvalidParams();
-            newAmount = currentAmount + uint208(amount);
+            // Check in uint256 first so oversized additions revert with InvalidParams()
+            // instead of relying on Solidity's checked-arithmetic panic.
+            if (amount > type(uint208).max || uint256(currentAmount) + amount > type(uint208).max) {
+                revert InvalidParams();
+            }
+            newAmount = uint208(uint256(currentAmount) + amount);
         }
 
         // Proposed expiry is “now + duration” in the Governor’s clock units (timestamp-mode).
@@ -501,10 +506,13 @@ contract DigilGovernor is Governor, GovernorStorage, GovernorVotes, GovernorTime
 
     /// @notice Stakes coins on the outcome of a governance proposal (PvP Prediction Market).
     /// @dev    Tokens are transferred from the user to the Governor. Can only be called during Pending or Active states.
+    ///         Zero-amount stakes are rejected to avoid meaningless market entries and event spam.
     /// @param  proposalId The ID of the proposal to stake on.
     /// @param  supportFor Set to `true` to bet that the proposal will succeed. Set to `false` to bet it will fail.
-    /// @param  amount The amount of DigilCoin to stake.
+    /// @param  amount The non-zero amount of DigilCoin to stake.
     function stake(uint256 proposalId, bool supportFor, uint256 amount) external {
+        if (amount == 0) revert InvalidParams();
+
         ProposalState currentState = state(proposalId);
 
         // Can only enter the market while voting is pending or active


### PR DESCRIPTION
### Motivation

- Prevent unsafe or confusing states by tightening parameter validation for spender allowlist entries, locked-amount arithmetic, and staking inputs.

### Description

- Update `DigilCoin.setSpendWeight` to allow disabling entries with `weightBps == 0` even if the target has no code, and to require `spender.code.length > 0` only when enabling a non-zero weight.
- Clarify NatSpec comments around spender eligibility and `weightBps` behavior.
- Harden `DigilGovernor.lockCoins` overflow checks by validating sums in `uint256` before casting to `uint208` and return `InvalidParams()` for oversized additions, then store the safely-cast `uint208` result.
- Reject zero-amount stakes in `DigilGovernor.stake` by reverting with `InvalidParams()` and update documentation to require a non-zero `amount`.

### Testing

- Ran unit tests with `forge test`; all tests passed.
- Ran static compilation checks with `forge build`; build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a043f32dd588326b74ef4401ea0e551)